### PR TITLE
Change README.md from gradientOpacity to opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The following properties can be configured:
 			</td>
 		</tr>
     <tr>
-			<td><code>gradientOpacity</code></td>
+			<td><code>opacity</code></td>
 			<td>Overall opacity of the gradient<br>
 				<br><b>Example:</b> <code>'.8'</code>
 				<br><b>Default value:</b> <code>'0.6'</code>


### PR DESCRIPTION
It looks like the README.md file lists gradientOpacity as a config item, but "opacity" is referenced in the code at https://github.com/darickc/MMM-BackgroundSlideshow/blob/master/MMM-BackgroundSlideshow.js#L97