### PR TITLE
Display image name in a panel at the bottom right of the screen

### DIFF
--- a/BackgroundSlideshow.css
+++ b/BackgroundSlideshow.css
@@ -11,3 +11,15 @@
   background-repeat: no-repeat;
   opacity: 0;
 }
+
+.info {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  background-color: rgba(0,0,0,0.3);
+  border-radius: 20px;
+  font-size: 11px;
+  line-height: 100%;
+  padding: 10px 12px;
+  text-align: left;
+}

--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -25,6 +25,8 @@ Module.register('MMM-BackgroundSlideshow', {
     recursiveSubDirectories: false,
     // list of valid file extensions, seperated by commas
     validImageFileExtensions: 'bmp,jpg,gif,png',
+    // show a panel containing information about the image currently displayed.
+    showmageInfo: false,
     // transition speed from one image to the other, transitionImages must be true
     transitionSpeed: '1s',
     // the sizing of the background image
@@ -150,6 +152,10 @@ Module.register('MMM-BackgroundSlideshow', {
       this.createGradientDiv('right', this.config.gradient, wrapper);
     }
 
+    if (this.config.showmageInfo) {
+      this.imageInfoDiv = this.createImageInfoDiv(wrapper);
+    }
+
     return wrapper;
   },
 
@@ -172,6 +178,13 @@ Module.register('MMM-BackgroundSlideshow', {
     return div;
   },
 
+  createImageInfoDiv: function(wrapper) {
+    const div = document.createElement('div');
+    div.className = 'info';
+    wrapper.appendChild(div);
+    return div;
+  },
+
   updateImage: function() {
     if (this.imageList && this.imageList.length) {
       if (this.imageIndex < this.imageList.length) {
@@ -180,13 +193,28 @@ Module.register('MMM-BackgroundSlideshow', {
         }
         var div1 = this.div1;
         var div2 = this.div2;
-
+        var imageInfoDiv = this.config.showmageInfo ? this.imageInfoDiv : null;
+        var recursiveSubDirectories = this.config.recursiveSubDirectories;
 
         var image = new Image();
         image.onload = function() {
           div1.style.backgroundImage = `url("${this.src}")`;
           div1.style.opacity = '1';
           div1.style.transform="rotate(0deg)";
+
+          if (imageInfoDiv) {
+            // Heuristic: display last path component as image name.
+            // If recursiveSubDirectories is set, display parent directory as well.
+            const pathComponents = decodeURI(this.src).split('/');
+            let imageName = pathComponents.pop();
+            // 3 = ['http', '', 'domain']
+            if (recursiveSubDirectories && pathComponents.length > 3) {
+              const dirName = pathComponents.pop();
+              imageName = `${dirName}/${imageName}`;
+            }
+            imageInfoDiv.innerHTML = imageName;
+          }
+
           EXIF.getData(image, function() {
             var Orientation = EXIF.getTag(this, "Orientation");
             if (Orientation == null) {

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ The following properties can be configured:
 				<br>This value is <b>OPTIONAL</b>
 			</td>
 		</tr>
+		<tr>
+			<td><code>showmageInfo</code></td>
+			<td>Boolean value, if true a bubble containing the currently displayed image file
+			name will be shown. The parent directory is also displayed if the
+			recursiveSubDirectories option is set to true.<br>
+				<br><b>Example:</b> <code>true</code>
+				<br><b>Default value:</b> <code>false</code>
+				<br>This value is <b>OPTIONAL</b>
+			</td>
+		</tr>
     <tr>
 			<td><code>transitionSpeed</code></td>
 			<td>Transition speed from one image to the other, transitionImages must be true. Must be a valid css transition duration.<br>


### PR DESCRIPTION
Add a showmageInfo configuration option to toggle behavior, default is false.
Currently the image file name is displayed, the parent directory is also shown if recursiveSubDirectories is set.

In the future, this area may be used to display image capture time or other EXIF information.

![imageInfo](https://user-images.githubusercontent.com/62788173/77953631-31113300-72d6-11ea-848c-dd771b892b51.jpg)
