### PR TITLE
Implement BACKGROUNDSLIDESHOW_PREVIOUS to go back to previous image

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ The following notifications can be used:
 			</td>
 		</tr>
 		<tr>
+			<td><code>BACKGROUNDSLIDESHOW_PREVIOUS</code></td>
+			<td>Change to the previous image, restart the timer for image changes only if already running<br>
+			</td>
+		</tr>
+		<tr>
 			<td><code>BACKGROUNDSLIDESHOW_PAUSE</code></td>
 			<td>Pause the timer for image changes<br>
 			</td>


### PR DESCRIPTION
Closes #34

Changes:
  - Implement BACKGROUNDSLIDESHOW_PREVIOUS to back up one image.
  - Comment out Log messages for notifications so they don't flood the browser console (clock sends one once per second).
  - Cleanup: use early returns in updateImage() to reduce nesting - no behavior change.