### PR TITLE
showImageInfo shows relative path when recurseSubdirectories is true

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -55,6 +55,7 @@ Module.register('MMM-BackgroundSlideshow', {
     // the direction the gradient goes, vertical or horizontal
     gradientDirection: 'vertical'
   },
+
   // load function
   start: function() {
     // add identifier to the config
@@ -75,15 +76,15 @@ Module.register('MMM-BackgroundSlideshow', {
     }
   },
 
-    getScripts: function() {
+  getScripts: function() {
 		return ["modules/" + this.name + "/node_modules/exif-js/exif.js"];
 	},
-
 
   getStyles: function() {
     // the css contains the make grayscale code
     return ['BackgroundSlideshow.css'];
   },
+
   // generic notification handler
   notificationReceived: function(notification, payload, sender) {
     if (sender) {
@@ -118,6 +119,7 @@ Module.register('MMM-BackgroundSlideshow', {
       }
     }
   },
+
   // the socket handler
   socketNotificationReceived: function(notification, payload) {
     // if an update was received
@@ -136,6 +138,7 @@ Module.register('MMM-BackgroundSlideshow', {
       }
     }
   },
+
   // Override dom generator.
   getDom: function() {
     var wrapper = document.createElement('div');
@@ -240,16 +243,7 @@ Module.register('MMM-BackgroundSlideshow', {
       this.div1.style.transform="rotate(0deg)";
 
       if (this.config.showmageInfo) {
-        // Heuristic: display last path component as image name.
-        // If recursiveSubDirectories is set, display parent directory as well.
-        const pathComponents = decodeURI(image.src).split('/');
-        let imageName = pathComponents.pop();
-        // 3 = ['http', '', 'domain']
-        if (this.config.recursiveSubDirectories && pathComponents.length > 3) {
-          const dirName = pathComponents.pop();
-          imageName = `${dirName}/${imageName}`;
-        }
-        this.imageInfoDiv.innerHTML = imageName;
+        this.updateImageInfo(decodeURI(image.src));
       }
 
       if (this.config.showProgressBar) {
@@ -294,6 +288,28 @@ Module.register('MMM-BackgroundSlideshow', {
     }
   },
 
+  updateImageInfo: function(imageSrc) {
+    // Only display last path component as image name if recurseSubDirectories is not set.
+    let imageName = imageSrc.split('/').pop();
+
+    // Otherwise display path relative to the path in configuration.
+    if (this.config.recursiveSubDirectories) {
+      for (const path of this.config.imagePaths) {
+        if (!imageSrc.includes(path)) {
+          continue;
+        }
+
+        imageName = imageSrc.split(path).pop();
+        if (imageName.startsWith('/')) {
+          imageName = imageName.substr(1);
+        }
+        break;
+      }
+    }
+
+    this.imageInfoDiv.innerHTML = imageName;
+  },
+
   swapDivs: function() {
     var temp = this.div1;
     this.div1 = this.div2;
@@ -306,6 +322,7 @@ Module.register('MMM-BackgroundSlideshow', {
       this.timer = null;
     }
   },
+
   resume: function() {
     //this.updateImage(); //Removed to prevent image change whenever MMM-Carousel changes slides
     this.suspend();
@@ -315,6 +332,7 @@ Module.register('MMM-BackgroundSlideshow', {
       self.updateImage();
     }, self.config.slideshowSpeed);
   },
+
   updateImageList: function() {
     this.suspend();
      // console.info('Getting Images');

--- a/README.md
+++ b/README.md
@@ -154,9 +154,8 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>showmageInfo</code></td>
-			<td>Boolean value, if true a bubble containing the currently displayed image file
-			name will be shown. The parent directory is also displayed if the
-			recursiveSubDirectories option is set to true.<br>
+			<td>Boolean value, if true a bubble containing the currently displayed image file name will be shown.
+			The relative path from that defined in imagePaths is displayed if the recursiveSubDirectories option is set to true.<br>
 				<br><b>Example:</b> <code>true</code>
 				<br><b>Default value:</b> <code>false</code>
 				<br>This value is <b>OPTIONAL</b>


### PR DESCRIPTION
Modify the behavior of showImageInfo so that instead of blindly showing only the parent directory, the relative path is now shown.

e.g. for a configuration of imagePaths = ['foo'] and an image at 'foo/bar/baz/image.jpg':
 * old behavior: 'baz/image.jpg' was displayed.
 * now 'bar/baz/image.jpg' is displayed.

Other cleanup in this cl:
 - Split out update of imageInfo into. its own function.
 - Make indent and spacing between functions uniform.

Tested manually.