### PR TITLE
Use Set() for image file filtering and add .jpeg to default extensions

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -21,10 +21,10 @@ Module.register('MMM-BackgroundSlideshow', {
     slideshowSpeed: 10 * 1000,
     // if true randomize image order, otherwise do alphabetical
     randomizeImageOrder: false,
-    // if false each path with be viewed seperately in the order listed
+    // if false each path with be viewed separately in the order listed
     recursiveSubDirectories: false,
-    // list of valid file extensions, seperated by commas
-    validImageFileExtensions: 'bmp,jpg,gif,png',
+    // list of valid file extensions, separated by commas
+    validImageFileExtensions: 'bmp,jpg,jpeg,gif,png',
     // show a panel containing information about the image currently displayed.
     showmageInfo: false,
     // transition speed from one image to the other, transitionImages must be true

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ The following properties can be configured:
 		</tr>
         <tr>
 			<td><code>validImageFileExtensions</code></td>
-			<td>String value, a list of image file extensions, seperated by commas, that should be included. Files found without one of the extensions will be ignored.<br>
+			<td>String value, a list of image file extensions, separated by commas, that should be included. Files found without one of the extensions will be ignored.<br>
 				<br><b>Example:</b> <code>'png,jpg'</code>
-				<br><b>Default value:</b> <code>'bmp,jpg,gif,png'</code>
+				<br><b>Default value:</b> <code>'bmp,jpg,jpeg,gif,png'</code>
 				<br>This value is <b>OPTIONAL</b>
 			</td>
 		</tr>


### PR DESCRIPTION
Changes:
* Instead of parsing config for each image file, create a Set() and use that to check image file extensions.
* Add .jpeg to default set of accepted image file types.
* ES6: Change some instances of var to const/let in node_helper.js.
* Remove some unneeded definitions of 'self'.
* Minor spelling correction and whitespace fixes.

Tested manually.