### PR TITLE
Add support for excluding named paths when scanning for images

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -17,6 +17,8 @@ Module.register('MMM-BackgroundSlideshow', {
   defaults: {
     // an array of strings, each is a path to a directory with images
     imagePaths: ['modules/MMM-BackgroundSlideshow/exampleImages'],
+    // do not recurse into these subdirectory names when scanning.
+    excludePaths: ['@eaDir'],
     // the speed at which to switch between images, in milliseconds
     slideshowSpeed: 10 * 1000,
     // if true randomize image order, otherwise use sortImagesBy and sortImagesDescending
@@ -174,7 +176,7 @@ Module.register('MMM-BackgroundSlideshow', {
           this.updateImage(false, payload.url);
         }
       } else if (notification === 'BACKGROUNDSLIDESHOW_URLS') {
-        console.log(`Notification Recieved: BACKGROUNDSLIDESHOW_URLS. Payload: ${JSON.stringify(payload)}`);
+        console.log(`Notification Received: BACKGROUNDSLIDESHOW_URLS. Payload: ${JSON.stringify(payload)}`);
         if (payload && payload.urls && payload.urls.length) {
           // check if image list has been saved. If not, this is the first time the notification is received
           // save the image list and index.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>excludePaths</code></td>
+			<td>Array value containing strings. When scanning subdirectories for
+			images, directories with these names will be ignored.<br>
+				<br><b>Example:</b> <code>['@eaDir']</code>
+				<br><b>Default value:</b> <code>['@eaDir']</code>
+				<br>This value is <b>OPTIONAL</b>
+			</td>
+		</tr>
+		<tr>
 			<td><code>slideshowSpeed</code></td>
 			<td>Integer value, the length of time to show one image before switching to the next, in milliseconds.<br>
 				<br><b>Example:</b> <code>6000</code> for 6 seconds

--- a/node_helper.js
+++ b/node_helper.js
@@ -20,6 +20,7 @@ var FileSystemImageSlideshow = require('fs');
 module.exports = NodeHelper.create({
   // subclass start method, clears the initial config array
   start: function() {
+    this.excludePaths = new Set();
     this.validImageFileExtensions = new Set();
   },
   
@@ -119,6 +120,9 @@ module.exports = NodeHelper.create({
   getFiles(path, imageList, config) {
     const contents = FileSystemImageSlideshow.readdirSync(path);
     for (let i = 0; i < contents.length; i++) {
+      if (this.excludePaths.has(contents[i])) {
+        continue;
+      }
       const currentItem = path + '/' + contents[i];
       const stats = FileSystemImageSlideshow.lstatSync(currentItem);
       if (stats.isDirectory() && config.recursiveSubDirectories) {
@@ -141,6 +145,9 @@ module.exports = NodeHelper.create({
   socketNotificationReceived: function(notification, payload) {
     if (notification === 'BACKGROUNDSLIDESHOW_REGISTER_CONFIG') {
       const config = payload;
+
+      // Create set of excluded subdirectories.
+      this.excludePaths = new Set(config.excludePaths);
 
       // Create set of valid image extensions.
       const validExtensionsList = config.validImageFileExtensions.toLowerCase().split(',');


### PR DESCRIPTION
This fixes Issue #26.

Add new excludePaths config option, directory names must match exactly.