### PR TITLE
added configuration option to change the image directly after resume

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -80,6 +80,7 @@ Module.register('MMM-BackgroundSlideshow', {
     ],
     transitionTimingFunction: 'cubic-bezier(.17,.67,.35,.96)',
     animations: ['slide', 'zoomOut', 'zoomIn'],
+    changeImageOnResume: false,
   },
 
   // load function
@@ -525,6 +526,11 @@ Module.register('MMM-BackgroundSlideshow', {
     //this.updateImage(); //Removed to prevent image change whenever MMM-Carousel changes slides
     this.suspend();
     var self = this;
+
+    if (self.config.changeImageOnResume) {
+      self.updateImage();
+    }
+
     this.timer = setInterval(function () {
       // console.info('MMM-BackgroundSlideshow updating from resume');
       self.updateImage();

--- a/README.md
+++ b/README.md
@@ -337,5 +337,13 @@ The following properties can be configured:
 				<br>This value is <b>OPTIONAL</b>
 			</td>
 		</tr>
+		<tr>
+			<td><code>changeImageOnResume</code></td>
+			<td>Should the image be changed in the moment the module resumes after it got hidden?
+				<br><b>Example:</b> <code>true</code>
+				<br><b>Default value:</b> <code>false</code>
+				<br>This value is <b>OPTIONAL</b>
+			</td>
+		</tr>
     </tbody>
 </table>


### PR DESCRIPTION
Hi,

i use the module in a picture frame with pages.
I saw in the code that you commented out the update of the image after the module got resumed. I re-added it but with an config option. The default behavior stays the same but i can re-activate it in my setup.
I also updated the Readme.
It would be great if merge it to your code.