### PR TITLE
Fix to make BACKGROUNDSLIDESHOW_URLS work

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -259,7 +259,7 @@ Module.register('MMM-BackgroundSlideshow', {
   },
 
   updateImageListWithArray: function (urls) {
-    this.imageList = urls;
+    this.imageList = urls.splice(0);
     this.imageIndex = 0;
     this.updateImage();
     if (

--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -556,6 +556,23 @@ Module.register('MMM-BackgroundSlideshow', {
       return;
     }
 
+    if (this.imageList.length > 0 ){
+      this.imageIndex = this.imageIndex + 1;
+
+      if (this.config.randomizeImageOrder){
+        this.imageIndex  = Math.floor(Math.random() * (this.imageList.length));
+      }
+
+      imageToDisplay = this.imageList.splice(this.imageIndex,1);
+      this.displayImage({
+        path: imageToDisplay[0],
+        data: imageToDisplay[0],
+        index: 1,
+        total: 1
+      });
+      return;
+    } 
+
     if (backToPreviousImage) {
       this.sendSocketNotification('BACKGROUNDSLIDESHOW_PREV_IMAGE');
     } else {


### PR DESCRIPTION
I want to use the BACKGROUNDSLIDESHOW_URLS notification but found out that it didnt work. 

After digging around in the code, i found that i```imageList``` and ```imageIndex``` were set but never used to present pictures.

The following codes uses both variables in the ```updateImage``` function until the imageList is empty, whereafter it will default on to the normal paths that have been set in the config.