### PR TITLE
replaced sharp call with jimp call at image resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "dependencies": {
     "exif-js": "^2.3.0",
     "lodash": "^4.17.21",
-    "sharp": "^0.28.2"
+    "jimp": "^0.16.1"
   }
 }


### PR DESCRIPTION
instead of system libraries jimp uses javascript functions to process the images; cause of this no recompile jimp is a little bit slower than sharp but no recompile is needed.

as i am not a javascript guru please review and test the change. i am open minded for changes and input