### PR TITLE
Rotate images before resize

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -17,7 +17,7 @@ const Log = require('../../js/logger.js');
 var NodeHelper = require('node_helper');
 var FileSystemImageSlideshow = require('fs');
 const Jimp = require('jimp');
-
+const jo = require('jpeg-autorotate');
 const { exec } = require('child_process');
 var express = require('express');
 const basePath = '/images/';
@@ -183,22 +183,76 @@ module.exports = NodeHelper.create({
     this.getNextImage();
   },
 
-  readFile: function (filepath, callback) {
+  readFile: async function (filepath, callback) {
     if (this.config.resizeImages) {
-      Jimp.read(filepath)
-        .then((image) => {
-          image
-            .scaleToFit(
-              parseInt(this.config.maxWidth),
-              parseInt(this.config.maxHeight)
-            )
-            .getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
-              callback('data:image/jpg;base64, ' + buffer.toString('base64'));
-            });
-        })
-        .catch((err) => {
-          console.log(err);
-        });
+      let ext = filepath.split('.').pop();
+      if (ext === 'jpg' || ext === 'jpeg') {
+        jo.rotate(
+          filepath,
+          { quality: 30 },
+          (error, buffer, orientation, dimensions, quality) => {
+            if (error) {
+              console.log(
+                'An error occurred when rotating the file: ' + error.message
+              );
+              Jimp.read(filepath)
+                .then((image) => {
+                  image
+                    .scaleToFit(
+                      parseInt(this.config.maxWidth),
+                      parseInt(this.config.maxHeight)
+                    )
+                    .getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
+                      callback(
+                        'data:image/jpg;base64, ' + buffer.toString('base64')
+                      );
+                    });
+                })
+                .catch((err) => {
+                  console.log(err);
+                });
+            } else {
+              Jimp.read(buffer)
+                .then((image) => {
+                  image
+                    .scaleToFit(
+                      parseInt(this.config.maxWidth),
+                      parseInt(this.config.maxHeight)
+                    )
+                    .getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
+                      callback(
+                        'data:image/jpg;base64, ' + buffer.toString('base64')
+                      );
+                    });
+                })
+                .catch((err) => {
+                  console.log(err);
+                });
+            }
+            console.log(`Orientation was ${orientation}`);
+            console.log(
+              `Dimensions after rotation: ${dimensions.width}x${dimensions.height}`
+            );
+            console.log(`Quality: ${quality}`);
+            // ...Do whatever you need with the resulting buffer...
+          }
+        );
+      } else {
+        Jimp.read(filepath)
+          .then((image) => {
+            image
+              .scaleToFit(
+                parseInt(this.config.maxWidth),
+                parseInt(this.config.maxHeight)
+              )
+              .getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
+                callback('data:image/jpg;base64, ' + buffer.toString('base64'));
+              });
+          })
+          .catch((err) => {
+            console.log(err);
+          });
+      }
     } else {
       var ext = filepath.split('.').pop();
       var data = FileSystemImageSlideshow.readFileSync(filepath, {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "exif-js": "^2.3.0",
     "lodash": "^4.17.21",
-    "jimp": "^0.16.1"
+    "jimp": "^0.16.1",
+    "jpeg-autorotate": "^8.0.1"
   }
 }


### PR DESCRIPTION
Added code to rotate jpg/jpeg images based on the exif orientation information before they get resized with Jimp functions.
Jimp removes every Exif information so the orientation change needs to be performed before any Jimp function is called.