### PR TITLE
add imageInfoNoFileExt config option (resolves #106)

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -98,7 +98,9 @@ Module.register('MMM-BackgroundSlideshow', {
     changeImageOnResume: false,
     resizeImages: false,
     maxWidth: 1920,
-    maxHeight: 1080
+    maxHeight: 1080,
+    // remove the file extension from image name
+    imageInfoNoFileExt: false,
   },
 
   // load function
@@ -629,6 +631,10 @@ Module.register('MMM-BackgroundSlideshow', {
               }
               break;
             }
+          }
+          // Remove file extension from image name.
+          if (this.config.imageInfoNoFileExt) {
+              imageName = imageName.split('.')[0];
           }
           imageProps.push(imageName);
           break;

--- a/README.md
+++ b/README.md
@@ -244,7 +244,15 @@ The following properties can be configured:
 				<br>This value is <b>OPTIONAL</b>
 			</td>
 		</tr>
-    	<tr>
+		<tr>
+			<td><code>imageInfoNoFileExt</code></td>
+			<td>Boolean value, if true the file extension will be removed before the image name is displayed.
+			<br>
+				<br><b>Example:</b> <code>true</code>
+				<br><b>Default value:</b> <code>false</code>
+				<br>This value is <b>OPTIONAL</b>
+			</td>
+		</tr>    	<tr>
 			<td><code>transitionSpeed</code></td>
 			<td>Transition speed from one image to the other, transitionImages must be true. Must be a valid css transition duration.<br>
 				<br><b>Example:</b> <code>'2s'</code>


### PR DESCRIPTION
pull request to incorporate @MacG-DD code from #106 for a config option to remove the file extension when displaying `name` in `imageInfo`

changed the code slightly to follow the naming pattern of related config options