### PR TITLE
Correct file extension trimming

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -629,7 +629,7 @@ Module.register('MMM-BackgroundSlideshow', {
           }
           // Remove file extension from image name.
           if (this.config.imageInfoNoFileExt) {
-            imageName = imageName.split('.')[0];
+            imageName = imageName.substring(0, imageName.lastIndexOf('.'));
           }
           imageProps.push(imageName);
           break;


### PR DESCRIPTION
Instead of trimming at the first "." in a file name, it trims from the last.  Preserving file names such as "M.C. Escher - Some Woodblock Print.jpg", etc.

(This is my first time editing a file on github, I hope I'm doing this right.)