### PR TITLE
Bugfix/double call on imagelist wrap

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -143,7 +143,6 @@ module.exports = NodeHelper.create({
     if (sendNotification) {
       this.sendSocketNotification('BACKGROUNDSLIDESHOW_READY', returnPayload);
     }
-    this.getNextImage();
   },
 
   getNextImage () {
@@ -306,6 +305,7 @@ module.exports = NodeHelper.create({
       this.config = config;
       setTimeout(() => {
         this.gatherImageList(config, true);
+        this.getNextImage();
       }, 200);
     } else if (notification === 'BACKGROUNDSLIDESHOW_PLAY_VIDEO') {
       Log.info('mw got BACKGROUNDSLIDESHOW_PLAY_VIDEO');

--- a/node_helper.js
+++ b/node_helper.js
@@ -180,8 +180,8 @@ module.exports = NodeHelper.create({
     this.startOrRestartTimer();
   },
 
-    // stop timer if it's running
-    stopTimer: function () {
+  // stop timer if it's running
+  stopTimer: function () {
     if (this.timer) {
       Log.debug('BACKGROUNDSLIDESHOW: stopping update timer');
       var it = this.timer;


### PR DESCRIPTION
This fixes a double call to getNextImage() whenever we wrap around `this.imageList`, which leads to an uncaught exception in the MMM console.

(Embarrassingly, the issue was introduced by #143 ...)