### PR TITLE
notificationReceived to start listening on the global socket which le…

### DIFF
--- a/MMM-BackgroundSlideshow.js
+++ b/MMM-BackgroundSlideshow.js
@@ -182,8 +182,23 @@ Module.register('MMM-BackgroundSlideshow', {
       this.resume();
     }
   },
-
-  // the socket handler
+  //Setup receiver for global notifications (other modules etc)
+  // Use for example with MMM-Remote-Control API: https://github.com/Jopyth/MMM-Remote-Control/tree/master/API
+  // to change image from buttons or curl:
+  // curl http://[your ip address]:8080/api/notification/BACKGROUNDSLIDESHOW_PREV or NEXT
+  // make sure to set address: "0.0.0.0", and secureEndpoints: false (or setup security according to readme!)
+  notificationReceived (notification, payload, sender) {
+	  if (notification === "BACKGROUNDSLIDESHOW_NEXT") {
+      this.sendSocketNotification('BACKGROUNDSLIDESHOW_NEXT_IMAGE')
+    } else if (notification === 'BACKGROUNDSLIDESHOW_PREV'){
+      this.sendSocketNotification('BACKGROUNDSLIDESHOW_PREV_IMAGE')
+    } else if (notification === 'BACKGROUNDSLIDESHOW_PAUSE'){
+      this.sendSocketNotification('BACKGROUNDSLIDESHOW_PAUSE')
+    } else if (notification === 'BACKGROUNDSLIDESHOW_PLAY') {
+      this.sendSocketNotification('BACKGROUNDSLIDESHOW_PLAY')
+    }
+	},
+  // the socket handler from node_helper.js
   socketNotificationReceived (notification, payload) {
     // if an update was received
 


### PR DESCRIPTION
I added notificationReceived to start listening on the global socket which lets other modules send commands to this module. Convenient to be able to use curl to change to next/previous image or stop/start the slideshow timer by using the MMM-Remote-Control module.
I  use for example with [MMM-Remote-Control API](https://github.com/Jopyth/MMM-Remote-Control/tree/master/API) for sending the notifications via curl like: 
curl http://[your ip address]:8080/api/notification/BACKGROUNDSLIDESHOW_PREV

but can also be added as a button etc. 