### PR TITLE
Retain metadata on image resize so that Image Info overlay still works

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -218,6 +218,7 @@ module.exports = NodeHelper.create({
         height: parseInt(this.config.maxHeight, 10),
         fit: 'inside',
       })
+      .keepMetadata()
       .jpeg({quality: 80});
 
     // Streama image data from file to transformation and finally to buffer


### PR DESCRIPTION
Since moving to Sharp for image resizing the image overlay no longer works. This fixes it.