### PR TITLE
Exclude images

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -108,7 +108,7 @@ module.exports = NodeHelper.create({
   excludedFiles (currentDir){
     try {
 	  const excludedFile = FileSystemImageSlideshow.readFileSync(currentDir + '/excludeImages.txt', 'utf8');
-	  const listOfExcludedFiles = excludedFile.split(/\r?\n/)
+	  const listOfExcludedFiles = excludedFile.split(/\r?\n/u)
 	  Log.info(`found excluded images list: in dir: ${currentDir} containing: ${listOfExcludedFiles.length} files`)
 	  return listOfExcludedFiles;
     } catch (err) {
@@ -117,7 +117,7 @@ module.exports = NodeHelper.create({
     }
   },
   isExcluded (filename, excludedImagesList){
-	  if(excludedImagesList.includes(filename.replace(/\.[a-zA-Z]{3,4}$/, ""))){
+	  if(excludedImagesList.includes(filename.replace(/\.[a-zA-Z]{3,4}$/u, ""))){
 		  Log.info(`${filename} is excluded in excludedImages.txt!`)
 		  return true
 	  }else{

--- a/node_helper.js
+++ b/node_helper.js
@@ -105,7 +105,25 @@ module.exports = NodeHelper.create({
       .toLowerCase();
     return this.validImageFileExtensions.has(fileExtension);
   },
-
+  excludedFiles (currentDir){
+    try {
+	  const excludedFile = FileSystemImageSlideshow.readFileSync(currentDir + '/excludeImages.txt', 'utf8');
+	  const listOfExcludedFiles = excludedFile.split(/\r?\n/)
+	  Log.info(`found excluded images list: in dir: ${currentDir} containing: ${listOfExcludedFiles.length} files`)
+	  return listOfExcludedFiles;
+    } catch (err) {
+	  //no excludeImages.txt in current folder
+	  return [];
+    }
+  },
+  isExcluded (filename, excludedImagesList){
+	  if(excludedImagesList.includes(filename.replace(/\.[a-zA-Z]{3,4}$/, ""))){
+		  Log.info(`${filename} is excluded in excludedImages.txt!`)
+		  return true
+	  }else{
+		  return false
+	  }
+  },
   // gathers the image list
   gatherImageList (config, sendNotification) {
     // Invalid config. retrieve it again
@@ -116,7 +134,8 @@ module.exports = NodeHelper.create({
     // create an empty main image list
     this.imageList = [];
     for (let i = 0; i < config.imagePaths.length; i++) {
-      this.getFiles(config.imagePaths[i], this.imageList, config);
+	  const excludedImagesList = this.excludedFiles(config.imagePaths[i])
+      this.getFiles(config.imagePaths[i], this.imageList, excludedImagesList, config);
     }
 
     this.imageList = config.randomizeImageOrder
@@ -266,9 +285,9 @@ module.exports = NodeHelper.create({
     }
   },
 
-  getFiles (imagePath, imageList, config) {
-    Log.info(`BACKGROUNDSLIDESHOW: Reading directory "${imagePath}" for images.`);
+  getFiles (imagePath, imageList, excludedImagesList, config) {
     const contents = FileSystemImageSlideshow.readdirSync(imagePath);
+    Log.info(`BACKGROUNDSLIDESHOW: Reading directory "${imagePath}" for images, found ${contents.length} files and directories`);
     for (let i = 0; i < contents.length; i++) {
       if (this.excludePaths.has(contents[i])) {
         continue;
@@ -276,11 +295,11 @@ module.exports = NodeHelper.create({
       const currentItem = `${imagePath}/${contents[i]}`;
       const stats = FileSystemImageSlideshow.lstatSync(currentItem);
       if (stats.isDirectory() && config.recursiveSubDirectories) {
-        this.getFiles(currentItem, imageList, config);
+        this.getFiles(currentItem, imageList, this.excludedFiles(currentItem), config);
       } else if (stats.isFile()) {
-        const isValidImageFileExtension =
-          this.checkValidImageFileExtension(currentItem);
-        if (isValidImageFileExtension) {
+        const isValidImageFileExtension = this.checkValidImageFileExtension(currentItem);
+		const isExcluded = this.isExcluded(contents[i], excludedImagesList)
+        if (isValidImageFileExtension && !isExcluded) {
           imageList.push({
             path: currentItem,
             created: stats.ctimeMs,


### PR DESCRIPTION
I am using a script to sync a lot of family photos from Dropbox to my rpi every morning. In my family photos there are some photos I dont want to be displayed on my MM, hence this commit enables me to put a `excludeImages.txt` in every folder that has one or several photos that I dont want MM to recognize. 

a `excludeImages.txt` can be put in every sub-directory that this module is scanning, and is just a text file with a list of image names to exclude. 
Example: 
This is one of the folders I sync from dropbox: 
```
rclone sync dropbox: /home/kalle/Pictures/ \
    --include "Camera Uploads/Spara/*.jpg" \
    --include "Camera Uploads/Spara/excludeImages.txt" \
    --ignore-case -P
```
and the `excludeImages.txt` would contain something like: 
```
imagename1
image 2
nude photo of me
```
Notice the image name does NOT contain the file endings for it to work in this implementation!