### PR TITLE
fix: check for filesArray before reading JSON file

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -309,10 +309,12 @@ module.exports = NodeHelper.create({
 
         filesArray = files.filter((file) => file.startsWith(baseFilename) && path.extname(file).toLowerCase() === `${imageFilenameEnumeratedEnd}.json`);
         // actually, there is only one file expected
-        jsonFilePath = path.join(imageDirectory, filesArray[0]);
-        Log.log('JSON:', jsonFilePath);
-        const jsonData = fs.readFileSync(jsonFilePath, 'utf8');
-        json_metadata = JSON.parse(jsonData);
+        if (filesArray.length > 0) {
+          jsonFilePath = path.join(imageDirectory, filesArray[0]);
+          Log.log('JSON:', jsonFilePath);
+          const jsonData = fs.readFileSync(jsonFilePath, 'utf8');
+          json_metadata = JSON.parse(jsonData);
+        }
       } else {
         Log.warn('Directory does not exist:', imageDirectory);
       }


### PR DESCRIPTION
resolves #184 

Adds a guard to the Google TakeOut JSON metadata from #182 so it doesn't throw `ERR_INVALID_ARG_TYPE` when no sidecar .json file exists for an image.